### PR TITLE
feat: add TWZRD Agent Intel to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Honest about what's checked.
 
 <sup>[back to top](#contents)</sup>
 
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust scoring MCP for AI agents on Solana — verify agent wallet identity before authorizing x402 micropayments in simulation pipelines | Free | Agent identity & trust |
 ## CFD — Computational Fluid Dynamics
 
 > Open-source solvers for fluid flow, heat transfer, and multiphysics.


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers** section.

TWZRD Agent Intel provides trust scoring for AI agent wallets on Solana. In CAE/simulation pipelines using AI agents, it enables verifying agent identity before authorizing access to compute-heavy simulation APIs and authorizing x402 micropayments.

**Free MCP config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```