### PR TITLE
Add yusong652/yade-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Honest about what's checked.
 - [kimimgo/viznoir](https://github.com/kimimgo/viznoir) `Python` `MCP` - Cinema-quality science visualization. 22 tools for rendering, slicing, contouring, volume rendering, and animating OpenFOAM/VTK/CGNS data via VTK. Headless EGL/OSMesa.
 - [llnl/paraview_mcp](https://github.com/llnl/paraview_mcp) `Python` `MCP` - Natural language control of ParaView via MCP. Multimodal LLM observes viewport for visual feedback (LLNL).
 - [webworn/openfoam-mcp-server](https://github.com/webworn/openfoam-mcp-server) `C++` `MCP` - OpenFOAM MCP server with Socratic questioning for CFD education and expert error resolution.
+- [yusong652/yade-mcp](https://github.com/yusong652/yade-mcp) `Python` `MCP` - Drives a live Yade DEM session: run code in the running simulation, submit long solves as background tasks, read state mid-run, and interrupt. Bundles a searchable Yade API corpus.
 
 <sup>[back to top](#contents)</sup>
 


### PR DESCRIPTION
Adds [yusong652/yade-mcp](https://github.com/yusong652/yade-mcp) to **MCP Servers** — an MCP server for [Yade](https://gitlab.com/yade-dev/trunk), the open-source DEM framework already listed under DEM.

Against the quality requirements:

- **Open source** — MIT, on GitHub.
- **Installable** — on PyPI as `yade-mcp`; `uvx yade-mcp`, nothing installed permanently.
- **Actively maintained** — commits this month.
- **T1 / AI-Native** — MCP server, so no star minimum applies.

What it does, briefly: it drives a **live** Yade session rather than a batch run — run code in the running simulation, submit a long solve as a background task, read state mid-run, interrupt and resubmit. Reads of a cycling simulation are consistent within a single timestep. Two documentation tools search a bundled Yade API corpus, so the agent consults the real API instead of guessing at it.

The engine-side half is a dependency-free bridge currently under review for Yade's official tree ([MR !1187](https://gitlab.com/yade-dev/trunk/-/merge_requests/1187)); the MCP server itself is this repository.

I placed it in **MCP Servers** only, in alphabetical order. Happy to also list it under **DEM** (the way viznoir is double-listed) if you'd prefer — say the word.

One question while I'm here: are MCP servers for **commercial** engines in scope? I maintain [itasca-mcp](https://github.com/yusong652/itasca-mcp) (MIT, PyPI, same architecture) for the Itasca suite — PFC, FLAC, 3DEC, MPoint, MassFlow. The server is open source, but the engines it drives are not, and I notice nothing in the list currently targets closed-source software. Entirely your call on scope — I'd rather ask than send a PR you'd have to close.